### PR TITLE
Fix login button redirect

### DIFF
--- a/projectforum/projects/templates/project_detail.html
+++ b/projectforum/projects/templates/project_detail.html
@@ -116,7 +116,7 @@
 
     {% elif project.status == 1 %}
         {% if not logged_in %}
-            <button class='btn btn-default'>Log in to apply!</button>
+            <a class='btn btn-default' href="{% url 'profile:login' %}?next={{ request.path }}">Log in to apply!</a>
         {% elif user in project.applicants.all %}
             <br/>
             Your application has been submitted. The project owner is


### PR DESCRIPTION
Add url to the "Log in to apply" button so that it links to the log in page and redirects back to the project description page after.
